### PR TITLE
Update regex to support multi-digit version segments

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 get_maven_versions() {
     # super clumsy regex to locate all Maven version tags on their history page
-    version=".*<td>(<b>)?([0-9]\.[0-9](\.[0-9])?(-[^<]*)?)(</b>)?</td>.*"
+    version=".*<td>(<b>)?([0-9]+\.[0-9]+(\.[0-9]+)?(-[^<]*)?)(</b>)?</td>.*"
 
     # iterate all lines coming back from the Maven release history
     for line in $(curl -s https://maven.apache.org/docs/history.html); do


### PR DESCRIPTION
Current version of the script skips maven versions past 3.9.9 (e.g. 3.9.10 and 3.9.11) because it doesn't take into account multi-digit version segments.
This MR aligns the regex used with the regex in `bin/latest-stable`

Example of the old regex: https://regex101.com/r/NizowC/2
Example of the new regex: https://regex101.com/r/2NWI7M/1