### PR TITLE
Correctly sort and filter versions

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -11,4 +11,4 @@ get_maven_versions() {
     done
 }
 
-get_maven_versions | sort -r | head -n 1
+get_maven_versions | sort --version-sort --unique --reverse | head -n 1

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,4 +15,4 @@ get_maven_versions() {
     done
 }
 
-get_maven_versions | sort -u | tr "\n" " "
+get_maven_versions | sort --version-sort --unique | tr "\n" " "


### PR DESCRIPTION
To correctly sort available versions list it's best to use `-V/--version-sort` and `-u/--unique` flags.

Example before the change:

```shell
$ mise ls-remote maven | grep 3.9
3.3.9
3.9.0
3.9.1
3.9.10
3.9.11
3.9.11-SNAPSHOT
3.9.12-SNAPSHOT
3.9.2
3.9.3
3.9.4
3.9.5
3.9.6
3.9.7
3.9.8
3.9.9
```
```shell
$ mise latest maven
3.9.9
```

Example after the change:

```shell
$ mise ls-remote maven | grep 3.9
3.3.9
3.9.0
3.9.1
3.9.2
3.9.3
3.9.4
3.9.5
3.9.6
3.9.7
3.9.8
3.9.9
3.9.10
3.9.11
3.9.11-SNAPSHOT
3.9.12-SNAPSHOT
```
```shell
$ mise latest maven
3.9.11
```

Additionally cli flags for the `sort` command are spelled out for clarity