### PR TITLE
Set the Maven environment variable according to the version

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,7 +2,7 @@
 
 # Set environment variables
 if [ "$(echo $ASDF_INSTALL_VERSION | cut -d '.' -f 1)" -eq "2" ]; then
-	export M2_HOME="$ASDF_INSTALL_PATH"
+    export M2_HOME="$ASDF_INSTALL_PATH"
 else
-	export MAVEN_HOME="$ASDF_INSTALL_PATH"
+    export MAVEN_HOME="$ASDF_INSTALL_PATH"
 fi

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Set environment variables
+if [ "$(echo $ASDF_INSTALL_VERSION | cut -d '.' -f 1)" -eq "2" ]; then
+	export M2_HOME="$ASDF_INSTALL_PATH"
+else
+	export MAVEN_HOME="$ASDF_INSTALL_PATH"
+fi


### PR DESCRIPTION
It exposes the environment variables MAVEN_HOME or M2_HOME when using the plugin. In the case of Maven version 2.x, the variable created is M2_HOME; for other versions, it is MAVEN_HOME.