### PR TITLE
fix: use Maven Central CDN as primary download source with Apache Archive fallback

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -14,22 +14,41 @@ install_maven() {
     build_copy_cleanup $version "$destdir"
 }
 
-# Download Maven source from Apache
+# Download Maven source from Apache.
+# Tries Maven Central CDN first (fast, high availability), then falls back
+# to Apache Archive (complete history). SNAPSHOT versions always use the
+# Apache Snapshots repository.
 get_maven() {
     local version=$1
     local destdir=$2
 
-    local major=$(echo $version | cut -d '.' -f 1)
-    local base="https://archive.apache.org/dist/maven"
-    local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
+    local major=$(echo "$version" | cut -d '.' -f 1)
 
+    # SNAPSHOT versions have their own dedicated repository
     if [[ $version == *SNAPSHOT ]]; then
         local url="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.maven&a=apache-maven&v=$version&e=tar.gz&c=bin"
+        curl -fLC - --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"
+        if [ ! $? -eq 0 ]; then
+            ASDF_MAVEN_ERROR="Could not download $url. Perhaps the version of Maven you're trying to install does not exist"
+        fi
+        return
     fi
 
-    curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"
+    # Primary: Maven Central CDN — fast, high availability
+    local cdn_url="https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$version/apache-maven-$version-bin.tar.gz"
+
+    # Fallback: Apache Archive — complete version history, but less reliable
+    local archive_url="https://archive.apache.org/dist/maven/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
+
+    if curl -fLC - --connect-timeout 10 --max-time 30 --retry 2 --retry-delay 2 -o "$destdir/$version.tar.gz" "$cdn_url"; then
+        return 0
+    fi
+
+    echo "Warning: Maven Central CDN download failed. Falling back to Apache Archive..." >&2
+
+    curl -fLC - --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$archive_url"
     if [ ! $? -eq 0 ]; then
-        ASDF_MAVEN_ERROR="Could not download $url. Perhaps the version of Maven you're trying to install does not exist"
+        ASDF_MAVEN_ERROR="Could not download Maven $version. Both Maven Central CDN and Apache Archive failed"
     fi
 }
 

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -6,7 +6,7 @@ get_maven_versions() {
     version=".*<td>(<b>)?([0-9]+\.[0-9]+(\.[0-9]+)?)(</b>)?</td>.*"
 
     # iterate all lines coming back from the Maven release history
-    for line in $(curl -s https://maven.apache.org/docs/history.html); do
+    for line in $(curl -s --connect-timeout 10 --max-time 60 https://maven.apache.org/docs/history.html); do
         [[ $line =~ $version ]] && echo ${BASH_REMATCH[2]}
     done
 }

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,12 +5,12 @@ get_maven_versions() {
     version=".*<td>(<b>)?([0-9]+\.[0-9]+(\.[0-9]+)?(-[^<]*)?)(</b>)?</td>.*"
 
     # iterate all lines coming back from the Maven release history
-    for line in $(curl -s https://maven.apache.org/docs/history.html); do
+    for line in $(curl -s --connect-timeout 10 --max-time 60 https://maven.apache.org/docs/history.html); do 
         [[ $line =~ $version ]] && echo ${BASH_REMATCH[2]}
     done
 
     snapshot_version="[0-9].*-SNAPSHOT"
-    for line in $(curl -s https://repository.apache.org/content/repositories/snapshots/org/apache/maven/apache-maven/maven-metadata.xml); do
+    for line in $(curl -s --connect-timeout 10 --max-time 60 https://repository.apache.org/content/repositories/snapshots/org/apache/maven/apache-maven/maven-metadata.xml); do
         [[ $line =~ $snapshot_version ]] && echo ${BASH_REMATCH[0]}
     done
 }


### PR DESCRIPTION
## Summary

Resolves #6

Addresses the recurring installation failures caused by `archive.apache.org`
unreliability, first reported in #5.

## Changes

**`bin/install`**
- Added `repo.maven.apache.org` as primary download source
- Kept `archive.apache.org` as fallback with a warning message
- Added `--connect-timeout 10` and `--max-time 30/60` to all `curl` calls
- SNAPSHOT handling is unchanged

**`bin/list-all`** / **`bin/latest-stable`**
- Added `--connect-timeout 10 --max-time 60` to prevent indefinite hangs
  when Apache infrastructure is slow

## Why Maven Central CDN?

`repo.maven.apache.org` is the official Maven Central repository, managed by
Sonatype with a global CDN. It hosts all stable Maven releases and is
significantly more reliable than the Apache Archive for day-to-day use.
The Archive is preserved as fallback to ensure older or less common versions
remain accessible.

## Testing

- [x] `mise install maven@3.6.3` ✅
- [x] `mise install maven@3.9.9` ✅  
- [x] `./tests/run-all.sh` — all 12 tests pass ✅